### PR TITLE
Fix installer download when temp. path is not set

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -1108,7 +1108,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR lpszCmdLine, int)
 				}
 
 				// install
-				std::wstring dlDest = _wgetenv(L"TEMP");
+				std::wstring dlDest = getDestDir();
 				dlDest += L"\\";
 				dlDest += ::PathFindFileName(dlUrl.c_str());
 

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -26,6 +26,7 @@
 #include <fstream>
 #include <string>
 #include <commctrl.h>
+#include <ShlObj_core.h>
 #include "resource.h"
 #include <shlwapi.h>
 #include "xmlTools.h"
@@ -928,6 +929,7 @@ std::wstring getDestDir(const GupNativeLang& nativeLang, const GupParameters& gu
 	envVar = _wgetenv(L"TMP");
 	if (envVar)
 		return envVar;
+
 	envVar = _wgetenv(L"AppData");
 	if (envVar)
 	{
@@ -936,6 +938,16 @@ std::wstring getDestDir(const GupNativeLang& nativeLang, const GupParameters& gu
 		if (::PathFileExists(result.c_str()))
 			return result;
 	}
+
+	LPWSTR path = nullptr;
+	const HRESULT hr = ::SHGetKnownFolderPath(FOLDERID_Downloads, 0, nullptr, &path);
+	if (SUCCEEDED(hr))
+	{
+		std::wstring result = path;
+		CoTaskMemFree(path);
+		return result;
+	}
+
 	std::wstring message = nativeLang.getMessageString("MSGID_NODOWNLOADFOLDER");
 	if (message.empty())
 		message = MSGID_DOWNLOADSTOPPED;

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -61,6 +61,7 @@ const wchar_t MSGID_DOWNLOADSTOPPED[] = L"Download is stopped by user. Update is
 const wchar_t MSGID_CLOSEAPP[] = L" is opened.\rUpdater will close it in order to process the installation.\rContinue?";
 const wchar_t MSGID_ABORTORNOT[] = L"Do you want to abort update download?";
 const wchar_t MSGID_UNZIPFAILED[] = L"Can't unzip:\nOperation not permitted or decompression failed";
+const wchar_t MSGID_NODOWNLOADFOLDER[] = L"Can't find a download folder";
 const wchar_t MSGID_HELP[] = L"Usage :\r\
 \r\
 gup --help\r\
@@ -919,7 +920,7 @@ bool runInstaller(const wstring& app2runPath, const wstring& binWindowsClassName
 
 // Returns a folder suitable for exe installer download destination.
 // In case of error, shows a message box and returns an empty string.
-std::wstring getDestDir()
+std::wstring getDestDir(const GupNativeLang& nativeLang, const GupParameters& gupParams)
 {
 	const wchar_t* envVar = _wgetenv(L"TEMP");
 	if (envVar)
@@ -935,7 +936,10 @@ std::wstring getDestDir()
 		if (::PathFileExists(result.c_str()))
 			return result;
 	}
-	::MessageBox(NULL, L"Can't find a download folder", L"Error", MB_ICONERROR | MB_OK);
+	std::wstring message = nativeLang.getMessageString("MSGID_NODOWNLOADFOLDER");
+	if (message.empty())
+		message = MSGID_DOWNLOADSTOPPED;
+	::MessageBox(NULL, message.c_str(), gupParams.getMessageBoxTitle().c_str(), MB_ICONERROR | MB_OK);
 	return {};
 }
 
@@ -1093,7 +1097,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR lpszCmdLine, int)
 				}
 
 				// install
-				std::wstring dlDest = getDestDir();
+				std::wstring dlDest = getDestDir(nativeLang, gupParams);
 				if (dlDest.empty())
 					return -1;
 				dlDest += L"\\";
@@ -1259,7 +1263,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR lpszCmdLine, int)
 		// Download executable bin
 		//
 
-		std::wstring dlDest = getDestDir();
+		std::wstring dlDest = getDestDir(nativeLang, gupParams);
 		if (dlDest.empty())
 			return -1;
 		dlDest += L"\\";

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -26,7 +26,6 @@
 #include <fstream>
 #include <string>
 #include <commctrl.h>
-#include <ShlObj_core.h>
 #include "resource.h"
 #include <shlwapi.h>
 #include "xmlTools.h"
@@ -923,6 +922,7 @@ bool runInstaller(const wstring& app2runPath, const wstring& binWindowsClassName
 // In case of error, shows a message box and returns an empty string.
 std::wstring getDestDir(const GupNativeLang& nativeLang, const GupParameters& gupParams)
 {
+	// Note: Other fallback directories may be Downloads, %UserProfile%, etc.
 	const wchar_t* envVar = _wgetenv(L"TEMP");
 	if (envVar)
 		return envVar;
@@ -939,18 +939,9 @@ std::wstring getDestDir(const GupNativeLang& nativeLang, const GupParameters& gu
 			return result;
 	}
 
-	LPWSTR path = nullptr;
-	const HRESULT hr = ::SHGetKnownFolderPath(FOLDERID_Downloads, 0, nullptr, &path);
-	if (SUCCEEDED(hr))
-	{
-		std::wstring result = path;
-		CoTaskMemFree(path);
-		return result;
-	}
-
 	std::wstring message = nativeLang.getMessageString("MSGID_NODOWNLOADFOLDER");
 	if (message.empty())
-		message = MSGID_DOWNLOADSTOPPED;
+		message = MSGID_NODOWNLOADFOLDER;
 	::MessageBox(NULL, message.c_str(), gupParams.getMessageBoxTitle().c_str(), MB_ICONERROR | MB_OK);
 	return {};
 }

--- a/src/xmlTools.cpp
+++ b/src/xmlTools.cpp
@@ -306,7 +306,7 @@ void GupExtraOptions::writeProxyInfo(const wchar_t* fn, const wchar_t* proxySrv,
 	newProxySettings.SaveFile();
 }
 
-std::wstring GupNativeLang::getMessageString(std::string msgID)
+std::wstring GupNativeLang::getMessageString(const std::string& msgID) const
 {
 	if (!_nativeLangRoot)
 		return L"";

--- a/src/xmlTools.h
+++ b/src/xmlTools.h
@@ -103,7 +103,7 @@ public:
 		_xmlDoc.LoadFile(xmlFileName);
 		_nativeLangRoot = _xmlDoc.FirstChild("GUP_NativeLangue");
 	};
-	std::wstring getMessageString(std::string msgID);
+	std::wstring getMessageString(const std::string& msgID) const;
 
 protected:
 	TiXmlNode *_nativeLangRoot;

--- a/vcproj/GUP.vcxproj
+++ b/vcproj/GUP.vcxproj
@@ -384,7 +384,7 @@ del ..\bin64\GUP.ipdb</Command>
       <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libcurl.lib;ZipLib.lib;zlib.lib;lzma.lib;bzip2.lib;comctl32.lib;shlwapi.lib;Shell32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcurl.lib;ZipLib.lib;zlib.lib;lzma.lib;bzip2.lib;comctl32.lib;shlwapi.lib;Shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\curl\builds\libcurl-vc15-ARM64-release-dll-ipv6-sspi-winssl\lib;Bin\arm64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>

--- a/vcproj/GUP.vcxproj
+++ b/vcproj/GUP.vcxproj
@@ -384,7 +384,7 @@ del ..\bin64\GUP.ipdb</Command>
       <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libcurl.lib;ZipLib.lib;zlib.lib;lzma.lib;bzip2.lib;comctl32.lib;shlwapi.lib;Shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcurl.lib;ZipLib.lib;zlib.lib;lzma.lib;bzip2.lib;comctl32.lib;shlwapi.lib;Shell32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\curl\builds\libcurl-vc15-ARM64-release-dll-ipv6-sspi-winssl\lib;Bin\arm64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Use a fallback TMP or TEMP and then use the current directory.

Fix #16