### PR TITLE
Avoid Divide by Zero condition

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -479,10 +479,13 @@ static size_t setProgress(HWND, double dlTotal, double dlSoFar, double, double)
 
 	size_t downloadedRatio = SendMessage(hProgressBar, PBM_DELTAPOS, 0, 0);
 
-	size_t step = size_t(dlSoFar * 100.0 / dlTotal - downloadedRatio);
+	if (dlTotal != 0)
+	{
+		size_t step = size_t(dlSoFar * 100.0 / dlTotal - downloadedRatio);
 
-	SendMessage(hProgressBar, PBM_SETSTEP, (WPARAM)step, 0);
-	SendMessage(hProgressBar, PBM_STEPIT, 0, 0);
+		SendMessage(hProgressBar, PBM_SETSTEP, (WPARAM)step, 0);
+		SendMessage(hProgressBar, PBM_STEPIT, 0, 0);
+	}
 
 	const size_t percentageLen = 1024;
 	wchar_t percentage[percentageLen];


### PR DESCRIPTION
Sometime curl sends total size for download as `0` which can lead to divide by zero exception.

![image](https://user-images.githubusercontent.com/14791461/140616745-a0fa0c99-94bb-4a25-ab17-c7aa95904de6.png)
