### PR TITLE
[FMR]:Show current and new version on update dialog

### DIFF
--- a/src/gup.rc
+++ b/src/gup.rc
@@ -75,7 +75,7 @@ EXSTYLE WS_EX_TOOLWINDOW | WS_EX_WINDOWEDGE
 CAPTION "Update available"
 FONT 8, "MS Shell Dlg", 0, 0, 0x1
 BEGIN
-    LTEXT           "An update package is available, do you want to download it?",IDC_YESNONEVERMSG,13,20,300,16
+    LTEXT           "An update package is available, do you want to download it?",IDC_YESNONEVERMSG,13,20,259,16
     PUSHBUTTON   "Yes",IDYES,50,60,50,14
     PUSHBUTTON   "No",IDNO,110,60,50,14
     PUSHBUTTON   "Never",IDCANCEL,170,60,50,14

--- a/src/translations/english.xml
+++ b/src/translations/english.xml
@@ -23,6 +23,8 @@
 <GUP_NativeLangue name="English" version="5.1.3">
 	<PopupMessages>
 		<MSGID_UPDATEAVAILABLE content="An update package is available, do you want to download it?" />
+		<MSGID_VERSIONCURRENT  content="Current version is   :" />
+		<MSGID_VERSIONNEW      content="Available version is :" />
 		
 		<MSGID_DOWNLOADPAGE content="Go to the download page" />
 		<MSGID_MOREINFO content="more info" />


### PR DESCRIPTION
Fixes issue #19

### param -px64 -v1.234
![image](https://user-images.githubusercontent.com/14791461/141690091-690965b5-ef44-4bf5-905b-dd986a068920.png)

### param -px64 -v8.19
![image](https://user-images.githubusercontent.com/14791461/141690310-8f4da186-c3af-4546-99da-021bfc71f05d.png)
