### PR TITLE
Update Taiwanese Mandarin translation

### DIFF
--- a/src/translations/taiwaneseMandarin.xml
+++ b/src/translations/taiwaneseMandarin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
     Copyright 2021 Don HO <don.h@free.fr>
-	
+
     This file is part of GUP for Notepad++
 
     GUP for Notepad++ is free software: you can redistribute it and/or modify
@@ -23,12 +23,12 @@
 <GUP_NativeLangue name="台灣繁體" version="5.1.3">
 	<PopupMessages>
 		<MSGID_UPDATEAVAILABLE content="有可更新的新版本，您要下載嗎？" />
-		
+
 		<MSGID_DOWNLOADPAGE content="進入官方網站下載頁面" />
-		<MSGID_MOREINFO content="更多相關信息" />
+		<MSGID_MOREINFO content="更多相關資訊" />
 		<!-- $MSGID_DOWNLOADPAGE$ and $MSGID_MOREINFO$ are place holders, don't translate them -->
 		<MSGID_GOTODOWNLOADPAGETEXT content="無更新&#xD;&#xD;或自動更新尚未啟動（$MSGID_MOREINFO$）&#xD;&#xD;$MSGID_DOWNLOADPAGE$來手動更新 Notepad++" />
-		
+
 		<MSGID_DOWNLOADSTOPPED content="用戶已停止下載。 更新被中止。" />
 		<MSGID_CLOSEAPP content=" 已開啟&#xD;更新程式將關閉它以便繼續安裝。&#xD;繼續嗎？" />
 		<MSGID_ABORTORNOT content="您要中止更新下載嗎？" />


### PR DESCRIPTION
Use a more appropriate translation of the word "`info`" in Taiwanese Mandarin.