### PR TITLE
Update swedish.xml

### DIFF
--- a/src/translations/swedish.xml
+++ b/src/translations/swedish.xml
@@ -23,8 +23,8 @@
 <GUP_NativeLangue name="Swedish" version="5.1.3">
 	<PopupMessages>
 		<MSGID_UPDATEAVAILABLE content="Ett uppdateringspaket är tillgängligt. Vill du ladda ned det?" />
-		<MSGID_VERSIONCURRENT  content="Nuvarande version   :" />
-		<MSGID_VERSIONNEW      content="Tillgänglig version :" />
+		<MSGID_VERSIONCURRENT  content="Nuvarande version :" />
+		<MSGID_VERSIONNEW      content="Tillgänglig version   :" />
 		
 		<MSGID_DOWNLOADPAGE content="Gå till nedladdningssidan" />
 		<MSGID_MOREINFO content="mer information" />


### PR DESCRIPTION
Adjusted white-spaces to make the version numbers more aligned:

### Before
![1](https://github.com/notepad-plus-plus/wingup/assets/17113053/9b9be3f9-5395-4506-aff5-6721947da5b3)
### After
![2](https://github.com/notepad-plus-plus/wingup/assets/17113053/35110447-569b-47dc-967c-2f1102a67b3c)
