### PR TITLE
set proxyauth to any available to fix corp proxies with windows logins Fix #49

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -796,6 +796,7 @@ bool downloadBinary(const wstring& urlFrom, const wstring& destTo, const wstring
 		{
 			curl_easy_setopt(curl, CURLOPT_PROXY, ws2s(proxyServerInfo.first).c_str());
 			curl_easy_setopt(curl, CURLOPT_PROXYPORT, proxyServerInfo.second);
+			curl_easy_setopt(curl, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
 		}
 		curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_ALLOW_BEAST | CURLSSLOPT_NO_REVOKE);
 
@@ -933,6 +934,7 @@ bool getUpdateInfo(const string& info2get, const GupParameters& gupParams, const
 		{
 			curl_easy_setopt(curl, CURLOPT_PROXY, ws2s(proxyServer.getProxyServer()).c_str());
 			curl_easy_setopt(curl, CURLOPT_PROXYPORT, proxyServer.getPort());
+			curl_easy_setopt(curl, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
 		}
 
 		curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_ALLOW_BEAST | CURLSSLOPT_NO_REVOKE);


### PR DESCRIPTION
Some corporate proxies use windows SSO using NTLM. 

libcurl already has support for this baked in, but unfortunately by default the updater only allows BASIC authentication (as per https://curl.se/libcurl/c/CURLOPT_PROXYAUTH.html, the default value is CURLAUTH_BASIC). By setting this option to CURLAUTH_ANY and setting the proxy string in npp to http://:@my.proxy.address/, this Just Works.

Fix #49