### PR TITLE
[xml] Update Corsican translation for wingup 5.2.9

### DIFF
--- a/src/translations/corsican.xml
+++ b/src/translations/corsican.xml
@@ -21,27 +21,33 @@
 <!-- This file is optional.-->
 
 <!--
-    History of Corsican translation for wingup
+    History of Corsican translation for wingup:
+		- Updated on June 29th, 2024 for version 5.2.9 by Patriccollu di Santa Maria è Sichè
 		- Created on February 13th, 2023 for version 5.2.4 by Patriccollu di Santa Maria è Sichè
 
-    The latest update is still available here:
+    The latest update is available here:
 	https://github.com/notepad-plus-plus/wingup/blob/master/src/translations/corsican.xml
 -->
 
-<GUP_NativeLangue name="Corsican" version="5.2.4">
+<GUP_NativeLangue name="Corsican" version="5.2.9">
 	<PopupMessages>
-		<MSGID_UPDATEAVAILABLE content="Un pacchettu di rinnovu hè dispunibule, vulete scaricallu ?" />
-		<MSGID_VERSIONCURRENT  content="A versione attuale hè     :" />
-		<MSGID_VERSIONNEW      content="A versione dispunibule hè :" />
+		<MSGID_UPDATETITLE content="Messa à livellu di Notepad++ dispunibule"/>
+		<MSGID_UPDATEAVAILABLE content="Un pacchettu di messa à livellu hè dispunibule, vulete scaricalla è installalla ?"/>
+		<MSGID_VERSIONCURRENT content="A versione attuale hè     :"/>
+		<MSGID_VERSIONNEW content="A versione dispunibule hè :"/>
+		<MSGID_UPDATEYES content="Sì"/>
+		<MSGID_UPDATEYESSILENT content="Sì (silenziosu)"/>
+		<MSGID_UPDATENo content="Nò"/>
+		<MSGID_UPDATENEVER content="Mai"/>
 		
-		<MSGID_DOWNLOADPAGE content="Andà à a pagina di scaricamentu" />
-		<MSGID_MOREINFO content="per sapene di più" />
+		<MSGID_DOWNLOADPAGE content="Andà à a pagina di scaricamentu"/>
+		<MSGID_MOREINFO content="per sapene di più"/>
 		<!-- $MSGID_DOWNLOADPAGE$ and $MSGID_MOREINFO$ are place holders, don't translate them -->
-		<MSGID_GOTODOWNLOADPAGETEXT content="Nisunu rinnovu ùn hè dispunibule&#xD;o a versione più recente ùn hè ancu pronta per esse scaricata ($MSGID_MOREINFO$)&#xD;&#xD;$MSGID_DOWNLOADPAGE$ per rinnovà Notepad++ manualmente." />
+		<MSGID_GOTODOWNLOADPAGETEXT content="Alcuna messa à livellu ùn hè dispunibule&#xD;o a versione più recente ùn hè ancu pronta per esse scaricata ($MSGID_MOREINFO$)&#xD;&#xD;$MSGID_DOWNLOADPAGE$ per mette à livellu Notepad++ manualmente."/>
 		
-		<MSGID_DOWNLOADSTOPPED content="U scaricamentu hè statu interrottu da l’utilizatore. U rinnovu hè abbandunatu." />
-		<MSGID_CLOSEAPP content=" hè apertu.&#xD;U rinnuvadore hà da chjodelu per lancià l’installazione.&#xD;Cuntinuà ?" />
-		<MSGID_ABORTORNOT content="Vulete interrompe u scaricamentu di u rinnovu ?" />
-		<MSGID_UNZIPFAILED content="Ùn si pò scumprime : l’operazione hè difesa o a scumpressione hè fiascata" />
+		<MSGID_DOWNLOADSTOPPED content="U scaricamentu hè statu interrottu da l’utilizatore. U rinnovu hè abbandunatu."/>
+		<MSGID_CLOSEAPP content=" hè apertu.&#xD;U rinnuvadore hà da chjodelu per lancià l’installazione.&#xD;Cuntinuà ?"/>
+		<MSGID_ABORTORNOT content="Vulete interrompe u scaricamentu di u rinnovu ?"/>
+		<MSGID_UNZIPFAILED content="Ùn si pò scumprime : l’operazione hè difesa o a scumpressione hè fiascata"/>
 	</PopupMessages>
 </GUP_NativeLangue>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:

 * https://github.com/notepad-plus-plus/wingup/commit/069edc21e28db01b13f88ac451aa71aea4889dfe Add an option to update silently
 * https://github.com/notepad-plus-plus/wingup/commit/d5a9c7fb7ecf7ccaa70dff7df87e382b8deeaddc Make Update available dialog entirely translatable

I also made the localization file pretty printed (indent only).

Cheers,
Patriccollu.