### PR TITLE
[xml] Update french 5.3.0

### DIFF
--- a/src/translations/french.xml
+++ b/src/translations/french.xml
@@ -24,8 +24,8 @@
 	<PopupMessages>
 		<MSGID_UPDATETITLE content="Mise à jour de Notepad++"/>
 		<MSGID_UPDATEAVAILABLE content="Une mise à jour est disponible, voulez-vous la télécharger et l’installer ?"/>
-		<MSGID_VERSIONCURRENT content="Version installée&#x9;&#x9;:  "/>
-		<MSGID_VERSIONNEW content="Version disponnible&#x9;:  "/>
+		<MSGID_VERSIONCURRENT content="La version installée&#x9;&#x9;:  "/>
+		<MSGID_VERSIONNEW content="La dernière version disponnible&#x9;:  "/>
 		<MSGID_UPDATEYES content="Oui"/>
 		<MSGID_UPDATEYESSILENT content="Oui en silence"/><!-- Espace réduit -->
 		<MSGID_UPDATENo content="Non"/>

--- a/src/translations/french.xml
+++ b/src/translations/french.xml
@@ -20,12 +20,12 @@
 
 <!-- This file is optional.-->
 
-<GUP_NativeLangue name="Français" version="5.3">
+<GUP_NativeLangue name="français" version="5.3">
 	<PopupMessages>
 		<MSGID_UPDATETITLE content="Mise à jour de Notepad++"/>
 		<MSGID_UPDATEAVAILABLE content="Une mise à jour est disponible, voulez-vous la télécharger et l’installer ?"/>
-		<MSGID_VERSIONCURRENT content="La version installée&#x9;&#x9;:  "/>
-		<MSGID_VERSIONNEW content="La dernière version disponnible&#x9;:  "/>
+		<MSGID_VERSIONCURRENT content="Version installée actuellement&#x9;:  "/>
+		<MSGID_VERSIONNEW content=" &#xD;Dernière version disponible&#x9;:  "/>
 		<MSGID_UPDATEYES content="Oui"/>
 		<MSGID_UPDATEYESSILENT content="Oui en silence"/><!-- Espace réduit -->
 		<MSGID_UPDATENo content="Non"/>
@@ -34,7 +34,7 @@
 		<MSGID_DOWNLOADPAGE content="aller à la page de téléchargement"/>
 		<MSGID_MOREINFO content="plus d’info"/>
 		<!-- $MSGID_DOWNLOADPAGE$ and $MSGID_MOREINFO$ are place holders, don't translate them -->
-		<MSGID_GOTODOWNLOADPAGETEXT content="Aucune mise à jour n’est disponible, &#xD;ou rien n’a encore été déclenché.&#xD;($MSGID_MOREINFO$).&#xD;&#xD;Pour mettre à jour Notepad++  manuellement,&#xD;$MSGID_DOWNLOADPAGE$."/>
+		<MSGID_GOTODOWNLOADPAGETEXT content="Aucune mise à jour n’est disponible, &#xD;ou rien n’a été déclenché à ce jour.&#xD;($MSGID_MOREINFO$).&#xD;&#xD;Pour mettre à jour Notepad++  manuellement,&#xD;$MSGID_DOWNLOADPAGE$."/>
 
 		<MSGID_DOWNLOADSTOPPED content="Le téléchargement est interrompu.&#xD;La mise à jour ne sera pas poursuivie."/>
 		<MSGID_CLOSEAPP content=" est ouvert.&#xD;Il sera fermé afin de pouvoir poursuivre l’installation.&#xD;Continuer ?"/>

--- a/src/translations/french.xml
+++ b/src/translations/french.xml
@@ -25,7 +25,7 @@
 		<MSGID_UPDATETITLE content="Mise à jour de Notepad++"/>
 		<MSGID_UPDATEAVAILABLE content="Une mise à jour est disponible, voulez-vous la télécharger et l’installer ?"/>
 		<MSGID_VERSIONCURRENT content="Version installée&#x9;&#x9;:  "/>
-		<MSGID_VERSIONNEW content="&#xD;Version disponnible&#x9;:  "/>
+		<MSGID_VERSIONNEW content="Version disponnible&#x9;:  "/>
 		<MSGID_UPDATEYES content="Oui"/>
 		<MSGID_UPDATEYESSILENT content="Oui en silence"/><!-- Espace réduit -->
 		<MSGID_UPDATENo content="Non"/>

--- a/src/translations/french.xml
+++ b/src/translations/french.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright 2021 Don HO <don.h@free.fr>
+    Copyright 2024 Don HO <don.h@free.fr>
 	
     This file is part of GUP for Notepad++
 
@@ -20,25 +20,25 @@
 
 <!-- This file is optional.-->
 
-<GUP_NativeLangue name="français" version="5.1.3">
+<GUP_NativeLangue name="français" version="5.3">
 	<PopupMessages>
-		<MSGID_UPDATETITLE content="Mise à jour de Notepad++ est disponible" />
-		<MSGID_UPDATEAVAILABLE content="Une mise à jour est disponible, voulez-vous la télécharger et l'installer?"/>
-		<MSGID_VERSIONCURRENT content="La version courante   :" />
-		<MSGID_VERSIONNEW content="La version disponible :" />
-		<MSGID_UPDATEYES content="Oui" />
-		<MSGID_UPDATEYESSILENT content="Oui (Silencieux)" />
-		<MSGID_UPDATENo content="Non" />
-		<MSGID_UPDATENEVER content="Jamais" />
+		<MSGID_UPDATETITLE content="Mise à jour de Notepad++"/>
+		<MSGID_UPDATEAVAILABLE content="Une mise à jour est disponible, voulez-vous la télécharger et l’installer ?"/>
+		<MSGID_VERSIONCURRENT content="Version installée&#x9;&#x9;:  "/>
+		<MSGID_VERSIONNEW content="&#xD;Version disponnible&#x9;:  "/>
+		<MSGID_UPDATEYES content="Oui"/>
+		<MSGID_UPDATEYESSILENT content="Oui en silence"/><!-- Espace réduit -->
+		<MSGID_UPDATENo content="Non"/>
+		<MSGID_UPDATENEVER content="Jamais"/>
 
-		<MSGID_DOWNLOADPAGE content="Aller à la page de téléchargement" />
-		<MSGID_MOREINFO content="plus d'info" />
+		<MSGID_DOWNLOADPAGE content="aller à la page de téléchargement"/>
+		<MSGID_MOREINFO content="plus d’info"/>
 		<!-- $MSGID_DOWNLOADPAGE$ and $MSGID_MOREINFO$ are place holders, don't translate them -->
-		<MSGID_GOTODOWNLOADPAGETEXT content="La mise à jour n'est pas disponible&#xD;ou elle n'est pas encore déclenchée&#xD;($MSGID_MOREINFO$).&#xD;&#xD;$MSGID_DOWNLOADPAGE$ pour mettre à jour Notepad++ manuellement." />
-		
-		<MSGID_DOWNLOADSTOPPED content="Le téléchargement est interrompu. La mise à jour ne sera pas poursuivie."/>
-		<MSGID_CLOSEAPP content=" est ouvert.&#xD;Il sera fermé afin de pouvoir poursuivre l'installation.&#xD;Continue?"/>
-		<MSGID_ABORTORNOT content="Etes-vous sûr d'interrompre le téléchargement?"/>
-		<MSGID_UNZIPFAILED content="Impossible de dézipper: l'opération n'est pas permise ou la décompression a échoué."/>
+		<MSGID_GOTODOWNLOADPAGETEXT content="Aucune mise à jour n’est disponible, &#xD;ou rien n’a encore été déclenché.&#xD;($MSGID_MOREINFO$).&#xD;&#xD;Pour mettre à jour Notepad++  manuellement,&#xD;$MSGID_DOWNLOADPAGE$."/>
+
+		<MSGID_DOWNLOADSTOPPED content="Le téléchargement est interrompu.&#xD;La mise à jour ne sera pas poursuivie."/>
+		<MSGID_CLOSEAPP content=" est ouvert.&#xD;Il sera fermé afin de pouvoir poursuivre l’installation.&#xD;Continuer ?"/>
+		<MSGID_ABORTORNOT content="Êtes-vous sûr de vouloir interrompre le téléchargement ?"/>
+		<MSGID_UNZIPFAILED content="Impossible de dézipper: l’opération n’est pas permise ou la décompression a échoué."/>
 	</PopupMessages>
 </GUP_NativeLangue>

--- a/src/translations/french.xml
+++ b/src/translations/french.xml
@@ -20,7 +20,7 @@
 
 <!-- This file is optional.-->
 
-<GUP_NativeLangue name="français" version="5.3">
+<GUP_NativeLangue name="Français" version="5.3">
 	<PopupMessages>
 		<MSGID_UPDATETITLE content="Mise à jour de Notepad++"/>
 		<MSGID_UPDATEAVAILABLE content="Une mise à jour est disponible, voulez-vous la télécharger et l’installer ?"/>

--- a/src/translations/french.xml
+++ b/src/translations/french.xml
@@ -20,7 +20,7 @@
 
 <!-- This file is optional.-->
 
-<GUP_NativeLangue name="français" version="5.3">
+<GUP_NativeLangue name="français" version="5.3.0">
 	<PopupMessages>
 		<MSGID_UPDATETITLE content="Mise à jour de Notepad++"/>
 		<MSGID_UPDATEAVAILABLE content="Une mise à jour est disponible, voulez-vous la télécharger et l’installer ?"/>


### PR DESCRIPTION
Good morning

A small improvement to the French.xml file in the Gup updater part.

Below are the dialog boxes depending on whether a update is present or not. 
The title of the dialog boxes does not seem meaningful to me and I suggest giving both boxes the same title « Mise à jour de Notepad++ » . 
It is therefore necessary to create a variable so that the translation of  « Notepad++Update » is possible in cases where there is no update. (e.g. MSGID_NOUPDATETITLE or something like that) 
For aesthetic reasons, I reversed the phrase « Aller à la page...,pour Maj manuelle » by « Pour Maj manuelle..., aller à la page de téléchargement. » 
We would also need to create a variable to allow the “Close” button to be translated. (MSGID_CLOSEBTN for example) 
For the Shift available box I removed is available in the title and I added tabs so that the double dots: are well aligned. 
I also changed the text « Oui (silencieux) » by « Oui en silence »  because space is limited. I also corrected the copyright date and version number (it is also possible to make the button wider).

![Capture d'écran 2024-07-16 201805](https://github.com/user-attachments/assets/d9d64607-59c9-46df-bace-a0e87498ba15)
![Capture d'écran 2024-07-16 200237](https://github.com/user-attachments/assets/b492d9b2-41a3-4052-b102-c15c41adf330)
![Capture d'écran 2024-07-16 201007](https://github.com/user-attachments/assets/9a039167-30e6-453a-84d6-5bbdf8b75bfd)
![Capture d'écran 2024-07-16 200619](https://github.com/user-attachments/assets/539a18ec-3788-4dab-aa50-c4008478e97f)

Obviously, some of these modifications deserve to be included in the “english.xml” file.

Sincerely.
