### PR TITLE
style: Make silent install option correctly understandable for spanish speakers

### DIFF
--- a/src/translations/spanish.xml
+++ b/src/translations/spanish.xml
@@ -27,7 +27,7 @@
 		<MSGID_VERSIONCURRENT content="Versión actual:"/>
 		<MSGID_VERSIONNEW content="Versión disponible:"/>
 		<MSGID_UPDATEYES content="Sí"/>
-		<MSGID_UPDATEYESSILENT content="Sí (sin sonido)"/>
+		<MSGID_UPDATEYESSILENT content="Sí (sin intervención)"/>
 		<MSGID_UPDATENo content="No"/>
 		<MSGID_UPDATENEVER content="Nunca"/>
 		


### PR DESCRIPTION
# What I did
See title.

`Notepad++` notified me today that there was a new version, but the second "Yes" caught my attention because it gave me the option to install it without sound (sin sonido), which I found amusing. 🤣 
After searching the repository, I found the configuration file and understood the true meaning of the option. So, in exchange for a good laugh, I've left this pull request. 😄 