### PR TITLE
Launch silent installer with and without "runNppAfterSilentInstall" param

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -68,7 +68,7 @@ static wstring dlFileName = L"";
 static wstring appIconFile = L"";
 static wstring nsisSilentInstallParam = L"";
 
-const wchar_t FLAG_NSIS_SILENT_INSTALL_PARAM[] = L"/closeRunningNpp /S /runNppAfterSilentInstall";
+wstring FLAG_NSIS_SILENT_INSTALL_PARAM = L"/closeRunningNpp /S /runNppAfterSilentInstall";
 
 
 const wchar_t FLAG_OPTIONS[] = L"-options";
@@ -659,7 +659,10 @@ LRESULT CALLBACK yesNoNeverDlgProc(HWND hWndDlg, UINT message, WPARAM wParam, LP
 					::SetDlgItemText(hWndDlg, IDNO, pUaDlgStrs->_noButton.c_str());
 
 				if (!g_hAppWnd)
+				{
 					::EnableWindow(::GetDlgItem(hWndDlg, IDCANCEL), FALSE); // no app-wnd to sent the updates disabling message signal
+					FLAG_NSIS_SILENT_INSTALL_PARAM = L"/closeRunningNpp /S";
+				}
 			}
 
 			goToScreenCenter(hWndDlg);


### PR DESCRIPTION
For the new feature of Notepad++: "Add option for updating Notepad++ on exit" (https://github.com/notepad-plus-plus/notepad-plus-plus/pull/16626), Notepad++ should not be relaunched, because after closing Notepad++ then updating Notepad++, updated Notepad++ relaunch is not expected.

In this commit We modify the installer parameter on the fly, according the présence of Notepad++ instance, to meet the both needs (updating on startup & on exit).

Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/pull/16626/files#r2155056335