### PR TITLE
Fix no error-msg when a plugin download failed

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -837,7 +837,10 @@ bool downloadBinary(const wstring& urlFrom, const wstring& destTo, const wstring
 	if (res != CURLE_OK)
 	{
 		if (!isSilentMode && doAbort == false)
-			::MessageBoxA(NULL, errorBuffer, "curl error", MB_OK);
+		{
+			std::wstring errMsg = L"A fail occurred while trying to download: \n" + urlFrom + L"\n\n" + s2ws(errorBuffer);
+			::MessageBoxW(NULL, errMsg.c_str(), L"curl error", MB_OK | MB_SYSTEMMODAL); // MB_SYSTEMMODAL ... need the WS_EX_TOPMOST (due to the possible progress-dlg...)
+		}
 
 		if (doAbort)
 		{
@@ -1285,7 +1288,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR lpszCmdLine, int)
 				if (dlStopped == L"")
 					dlStopped = MSGID_DOWNLOADSTOPPED;
 
-				bool isSuccessful = downloadBinary(dlUrl, dlDest, sha256ToCheck, pair<wstring, int>(extraOptions.getProxyServer(), extraOptions.getPort()), true, pair<wstring, wstring>(dlStopped, gupParams.getMessageBoxTitle()));
+				bool isSuccessful = downloadBinary(dlUrl, dlDest, sha256ToCheck, pair<wstring, int>(extraOptions.getProxyServer(), extraOptions.getPort()), false, pair<wstring, wstring>(dlStopped, gupParams.getMessageBoxTitle()));
 				if (isSuccessful)
 				{
 					isSuccessful = decompress(dlDest, destPath);


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/wingup/issues/95
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/17044

<img width="445" height="223" alt="gup-plugin-download-curl-error" src="https://github.com/user-attachments/assets/774b194d-b29b-477c-93b9-e123cf3044b6" />
