### PR TITLE
Launch only program signed with WinGUp's certificate on plugin management

### DIFF
--- a/src/verifySignedfile.h
+++ b/src/verifySignedfile.h
@@ -53,8 +53,11 @@ class SecurityGuard final
 {
 public:
 	SecurityGuard(){};
-	bool verifySignedBinary(const std::wstring& filepath);
+	bool initFromSelfCertif();
 
+	bool verifySignatureAndGetInfo(const std::wstring& codeSigedBinPath, std::wstring& display_name, std::wstring& key_id_hex, std::wstring& subject, std::wstring& authority_key_id_hex);
+	bool verifySignedBinary(const std::wstring& filepath);
+	
 	void enableChkRevoc() { _doCheckRevocation = true; }
 	void enableChkTrustChain() { _doCheckChainOfTrust = true; }
 	void setDisplayName(const std::wstring& signer_display_name) { _signer_display_name = signer_display_name; }

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -1461,7 +1461,28 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR lpszCmdLine, int)
 			deleteFileOrFolder(destPath);
 		}
 
-		::ShellExecute(NULL, L"open", L"explorer.exe", prog2Launch.c_str(), prog2LaunchDir, SW_SHOWNORMAL);
+
+
+#ifdef _DEBUG
+		// Don't check any thing in debug mode
+#else
+		// Check signature of the launched program, with the same certif as gup.exe
+		SecurityGuard securityGuard4PluginsInstall;
+
+		if (!securityGuard4PluginsInstall.initFromSelfCertif())
+		{
+			securityGuard.writeSecurityError(L"Above certificate init error from \"gup -clean\" (remove plugins)", L"");
+			return -1;
+		}
+
+		bool isSecured = securityGuard4PluginsInstall.verifySignedBinary(prog2Launch.c_str());
+		if (!isSecured)
+		{
+			securityGuard.writeSecurityError(L"Above certificate verification error from \"gup -clean\" (remove plugins)", L"");
+			return -1;
+		}
+#endif
+		::ShellExecute(NULL, L"open", prog2Launch.c_str(), NULL, prog2LaunchDir, SW_SHOWNORMAL);
 
 		return 0;
 	}
@@ -1480,12 +1501,32 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR lpszCmdLine, int)
 			WRITE_LOG(GUP_LOG_FILENAME, L"-1 in plugin updater's part - if (isCleanUp && isUnzip) // update: ", L"nbParam < 3");
 			return -1;
 		}
+
 		wstring prog2Launch = params[0];
 		wchar_t prog2LaunchDir[MAX_PATH];
 		lstrcpy(prog2LaunchDir, prog2Launch.c_str());
 		::PathRemoveFileSpec(prog2LaunchDir);
 		wstring destPathRoot = params[1];
 
+#ifdef _DEBUG
+		// Don't check any thing in debug mode
+#else
+		// Check signature of the launched program, with the same certif as gup.exe
+		SecurityGuard securityGuard4PluginsInstall;
+
+		if (!securityGuard4PluginsInstall.initFromSelfCertif())
+		{
+			securityGuard.writeSecurityError(L"Above certificate init error from \"gup -unzip\" (install or update plugins)", L"");
+			return -1;
+		}
+
+		bool isSecured = securityGuard4PluginsInstall.verifySignedBinary(prog2Launch.c_str());
+		if (!isSecured)
+		{
+			securityGuard.writeSecurityError(L"Above certificate verification error from \"gup -unzip\" (install or update plugins)", L"");
+			return -1;
+		}
+#endif
 		for (size_t i = 2; i < nbParam; ++i)
 		{
 			wstring destPath = destPathRoot;
@@ -1593,7 +1634,8 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR lpszCmdLine, int)
 			}
 		}
 
-		::ShellExecute(NULL, L"open", L"explorer.exe", prog2Launch.c_str(), prog2LaunchDir, SW_SHOWNORMAL);
+		::ShellExecute(NULL, L"open", prog2Launch.c_str(), NULL, prog2LaunchDir, SW_SHOWNORMAL);
+
 		return 0;
 	}
 


### PR DESCRIPTION
While using -clean or -unzip for plugin management, WinGUp retrieves its own signing certificate, and compare it with the program to be launched. If the certificates do not match, or one of bineries is not signed, the program is not launched.